### PR TITLE
Remove "pool" option from vitest.config.ts

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,6 @@ export default defineConfig({
   test: {
     name: "jsdomTest",
     environment: "jsdom",
-    pool: "forks",
     poolOptions: {
       threads: {
         singleThread: true,


### PR DESCRIPTION
pool : forkとシングルスレッドオプションを併用すると、シングルスレッドで動作しない場合があるため。