### PR TITLE
Fix workflow trigger for NPM release

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,7 +1,7 @@
 name: Publish to NPM
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   npm-publish:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Update the workflow to trigger on the 'published' event instead of 'created' for NPM releases.