### PR TITLE
[Bug Fix] Fix event throttling and duplicate drag events in multi-touch environment

### DIFF
--- a/__test__/WatcherGenerator.ts
+++ b/__test__/WatcherGenerator.ts
@@ -3,7 +3,6 @@ import {
   DragWatcher,
   DragWatcherInitOption,
 } from "../src/index.js";
-import { Vector4 } from "three";
 import {
   FakePointerEventInit,
   getPointerEvent,

--- a/__test__/drag.pinch.spec.ts
+++ b/__test__/drag.pinch.spec.ts
@@ -140,21 +140,27 @@ describe("threejs-drag-watcher.dragWatcher.pinch", () => {
   });
 
   test("should not emit drag events during pinch operation", () => {
-    /**
-     * 2本のポインターでドラッグを開始した場合、moveは発行されない
-     */
+    //1本目のポインターでは、drag_startが発行される
     dispatchMouseEvent(canvas, "pointerdown", {
       offsetX: 100,
       offsetY: 100,
       pointerId: 1,
     });
+    expect(mockDragCallback).toHaveBeenCalledTimes(1);
+    mockDragCallback.mockClear();
+
+    //2本目のポインターを追加、drag_startは発行されない
     dispatchMouseEvent(canvas, "pointerdown", {
       offsetX: 200,
       offsetY: 200,
       pointerId: 2,
     });
+    expectMouseNotCall(mockDragCallback);
     mockDragCallback.mockClear();
 
+    /**
+     * 2本のポインターでドラッグを開始した場合、moveは発行されない
+     */
     dispatchMouseEvent(canvas, "pointermove", {
       offsetX: 101,
       offsetY: 101,
@@ -166,6 +172,21 @@ describe("threejs-drag-watcher.dragWatcher.pinch", () => {
       pointerId: 2,
     });
     expectMouseNotCall(mockDragCallback);
+
+    //1本目のポインターでは、drag_endが発行されない
+    dispatchMouseEvent(canvas, "pointerup", {
+      offsetX: 100,
+      offsetY: 100,
+      pointerId: 1,
+    });
+    expectMouseNotCall(mockDragCallback);
+    dispatchMouseEvent(canvas, "pointerup", {
+      offsetX: 201,
+      offsetY: 201,
+      pointerId: 2,
+    });
+    expect(mockDragCallback).toHaveBeenCalledTimes(1);
+    mockDragCallback.mockClear();
 
     clearCanvas(canvas, watcher, mockDragCallback, mockMoveCallback);
   });

--- a/__test__/drag.pinch.spec.ts
+++ b/__test__/drag.pinch.spec.ts
@@ -8,6 +8,7 @@ import {
 import { describe, test, vi, beforeEach, expect } from "vitest";
 
 const { canvas, watcher } = generateWatcher();
+
 const mockDragCallback = vi.fn((e) => {
   e;
 });
@@ -134,6 +135,37 @@ describe("threejs-drag-watcher.dragWatcher.pinch", () => {
     });
     expect(mockPinchCallback).toHaveBeenCalledTimes(1);
     mockPinchCallback.mockClear();
+
+    clearCanvas(canvas, watcher, mockDragCallback, mockMoveCallback);
+  });
+
+  test("should not emit drag events during pinch operation", () => {
+    /**
+     * 2本のポインターでドラッグを開始した場合、moveは発行されない
+     */
+    dispatchMouseEvent(canvas, "pointerdown", {
+      offsetX: 100,
+      offsetY: 100,
+      pointerId: 1,
+    });
+    dispatchMouseEvent(canvas, "pointerdown", {
+      offsetX: 200,
+      offsetY: 200,
+      pointerId: 2,
+    });
+    mockDragCallback.mockClear();
+
+    dispatchMouseEvent(canvas, "pointermove", {
+      offsetX: 101,
+      offsetY: 101,
+      pointerId: 1,
+    });
+    dispatchMouseEvent(canvas, "pointermove", {
+      offsetX: 201,
+      offsetY: 201,
+      pointerId: 2,
+    });
+    expectMouseNotCall(mockDragCallback);
 
     clearCanvas(canvas, watcher, mockDragCallback, mockMoveCallback);
   });

--- a/demoSrc/demo_pinch.js
+++ b/demoSrc/demo_pinch.js
@@ -1,0 +1,108 @@
+import { DragWatcher } from "../esm/index.js";
+
+const onDomContentsLoaded = () => {
+  const canvas = document.getElementById("webgl-canvas");
+
+  // デバッグ情報表示エリアを生成
+  const debugInfo = document.createElement("div");
+  debugInfo.style.cssText = `
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    background: rgba(0, 0, 0, 0.7);
+    color: white;
+    padding: 10px;
+    font-family: monospace;
+    pointer-events: none;
+    z-index: 1000;
+  `;
+  document.body.appendChild(debugInfo);
+
+  // ポインター位置を表示する要素のコンテナ
+  const pointerContainer = document.createElement("div");
+  pointerContainer.style.cssText = `
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1000;
+  `;
+  document.body.appendChild(pointerContainer);
+
+  // ポインターIDから色を生成
+  const generateColorFromPointerId = (id) => {
+    const hue = (id * 137.508) % 360;
+    return `hsl(${hue}, 70%, 50%)`;
+  };
+
+  // DragWatcherの初期化
+  const watcher = new DragWatcher(canvas);
+
+  // ピンチイベントのハンドラ
+  watcher.on("pinch", (e) => {
+    // デバッグ情報を更新
+    const currentTime = performance.now().toFixed(2);
+    debugInfo.innerHTML = `
+      Time: ${currentTime}ms<br>
+      Delta: ${e.delta.toFixed(2)}<br>
+      Active Pointers: ${e.pointers.length}<br>
+      Pointer IDs: ${e.pointers.map((p) => p.pointerId).join(", ")}<br>
+      Throttling: ${watcher.throttlingTime_ms}ms
+    `;
+
+    // ポインターマーカーを更新
+    pointerContainer.innerHTML = "";
+    e.pointers.forEach((pointer) => {
+      // ポインターマーカー
+      const marker = document.createElement("div");
+      const color = generateColorFromPointerId(pointer.pointerId);
+      marker.style.cssText = `
+        position: absolute;
+        left: ${pointer.offsetX}px;
+        top: ${pointer.offsetY}px;
+        width: 200px;
+        height: 200px;
+        border-radius: 50%;
+        background: ${color};
+        transform: translate(-50%, -50%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: white;
+        font-size: 48px;
+        font-weight: bold;
+      `;
+      marker.textContent = pointer.pointerId;
+      pointerContainer.appendChild(marker);
+    });
+
+    // 2点間の線を描画
+    if (e.pointers.length === 2) {
+      const [p1, p2] = e.pointers;
+      const line = document.createElement("div");
+      const dx = p2.offsetX - p1.offsetX;
+      const dy = p2.offsetY - p1.offsetY;
+      const length = Math.sqrt(dx * dx + dy * dy);
+      const angle = Math.atan2(dy, dx) * (180 / Math.PI);
+
+      line.style.cssText = `
+        position: absolute;
+        left: ${p1.offsetX}px;
+        top: ${p1.offsetY}px;
+        width: ${length}px;
+        height: 2px;
+        background: rgba(255, 255, 255, 0.5);
+        transform: rotate(${angle}deg);
+        transform-origin: left center;
+      `;
+      pointerContainer.appendChild(line);
+    }
+  });
+
+  // タッチアクションを無効化
+  canvas.style.touchAction = "none";
+};
+
+window.onload = onDomContentsLoaded;

--- a/demoSrc/demo_simple.js
+++ b/demoSrc/demo_simple.js
@@ -4,7 +4,40 @@ import * as THREE from "three";
 const W = 1280;
 const H = 640;
 
+const generateColorFromPointerId = (id) => {
+  const hue = (id * 137.508) % 360;
+  return `hsl(${hue}, 70%, 50%)`;
+};
+
 const onDomContentsLoaded = () => {
+  // デバッグ情報表示エリアを生成
+  const debugInfo = document.createElement("div");
+  debugInfo.style.cssText = `
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    background: rgba(0, 0, 0, 0.7);
+    color: white;
+    padding: 10px;
+    font-family: monospace;
+    pointer-events: none;
+    z-index: 1000;
+  `;
+  document.body.appendChild(debugInfo);
+
+  // ポインター位置を表示する要素のコンテナ
+  const pointerContainer = document.createElement("div");
+  pointerContainer.style.cssText = `
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1000;
+  `;
+  document.body.appendChild(pointerContainer);
+
   // シーンを作成
   const scene = new THREE.Scene();
   const camera = new THREE.PerspectiveCamera(45, W / H, 1, 10000);
@@ -28,17 +61,82 @@ const onDomContentsLoaded = () => {
   //ドラッグ監視処理を開始
   const watcher = new DragWatcher(renderer.domElement);
   watcher.on("drag", (e) => {
-    console.log(
-      `throttlingTime_ms : ${watcher.throttlingTime_ms}`,
-      `TimeStamp : ${performance.now()}`,
-      e,
-    );
+    const currentTime = performance.now().toFixed(2);
+    debugInfo.innerHTML = `
+      Status: drag<br>
+      Time: ${currentTime}ms<br>
+      throttlingTime_ms: ${watcher.throttlingTime_ms}<br>
+      Pointer ID: ${e.pointerId}<br>
+      Position: (${e.positionX}, ${e.positionY})<br>
+      Delta: (${e.deltaX ?? 0}, ${e.deltaY ?? 0})
+    `;
+
+    // ポインターマーカーを更新
+    pointerContainer.innerHTML = "";
+    const marker = document.createElement("div");
+    const color = generateColorFromPointerId(e.pointerId);
+    marker.style.cssText = `
+      position: absolute;
+      left: ${e.positionX}px;
+      top: ${e.positionY}px;
+      width: 80px;
+      height: 80px;
+      border-radius: 50%;
+      background: ${color};
+      transform: translate(-50%, -50%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-weight: bold;
+    `;
+    marker.textContent = e.pointerId;
+    pointerContainer.appendChild(marker);
   });
+
   watcher.on("drag_start", (e) => {
-    console.log(e);
+    const currentTime = performance.now().toFixed(2);
+    debugInfo.innerHTML = `
+      Status: drag_start<br>
+      Time: ${currentTime}ms<br>
+      Pointer ID: ${e.pointerId}<br>
+      Position: (${e.positionX}, ${e.positionY})
+    `;
+
+    // 開始位置にマーカーを表示
+    pointerContainer.innerHTML = "";
+    const marker = document.createElement("div");
+    const color = generateColorFromPointerId(e.pointerId);
+    marker.style.cssText = `
+      position: absolute;
+      left: ${e.positionX}px;
+      top: ${e.positionY}px;
+      width: 80px;
+      height: 80px;
+      border-radius: 50%;
+      background: ${color};
+      transform: translate(-50%, -50%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-weight: bold;
+    `;
+    marker.textContent = e.pointerId;
+    pointerContainer.appendChild(marker);
   });
+
   watcher.on("drag_end", (e) => {
-    console.log(e);
+    const currentTime = performance.now().toFixed(2);
+    debugInfo.innerHTML = `
+      Status: drag_end<br>
+      Time: ${currentTime}ms<br>
+      Pointer ID: ${e.pointerId}<br>
+      Position: (${e.positionX}, ${e.positionY})
+    `;
+
+    // マーカーを削除
+    pointerContainer.innerHTML = "";
   });
   watcher.on("zoom", (e) => {
     console.log(e);


### PR DESCRIPTION
### Issues to be Resolved

1. Event Throttling Mechanism
   - Current Behavior: The throttling process does not account for multi-touch environments, causing one pointer to incorrectly throttle events from other pointers, interfering with proper operation
   - Expected Behavior: Each pointer's events are throttled independently, ensuring smooth operation in multi-touch scenarios

2. Duplicate Drag Events in Multi-touch Environment
   - Current Behavior: `drag_start` and `drag_end` events are fired multiple times when multiple touch points exist, causing unintended event duplications
   - Expected Behavior: `drag_start` is fired only on first pointer down, and `drag_end` only on last pointer release, ensuring proper event sequence

#### Impact Level
Patch: Bug fixes for existing functionality while maintaining API compatibility.

#### Implementation Details
1. Throttling Mechanism Improvements
   - Implement pointer-specific event throttling
   - Ensure each pointer's events are processed independently
   - Optimize event firing timing for multi-touch scenarios

2. Multi-touch Control Enhancement
   - Implement proper event lifecycle management:
     - Single `drag_start` event on first pointer down
     - Single `drag_end` event on last pointer release
   - Properly control drag events during pinch operations

#### Test Changes
Added the following tests to verify fixes:
- Event throttling verification during multi-touch
- Verification of single drag_start/drag_end events in multi-touch scenarios
- Multiple pointer control verification

Modified test files:
- `__test__/drag.pinch.spec.ts`
- `__test__/WatcherGenerator.ts`

#### Dependency Status
No changes to dependencies.

#### Additional Notes
The following supplementary changes were made for verification:
- Added debug information display
- Implemented pinch event demo page

---

### PR本文（日本語）

#### 解決する課題
1. イベントスロットリング機構
   - 現状の挙動：スロットリング処理がマルチタッチ環境を考慮していないため、あるポインターの処理が他のポインターのイベントまでスロットリングしてしまい、正常な動作を妨げている
   - 期待される挙動：各ポインターのイベントが独立してスロットリングされ、マルチタッチ操作時でも滑らかに動作する

2. マルチタッチ環境でのドラッグイベントの重複
   - 現状の挙動：複数のタッチポイントが存在する際に、`drag_start`と`drag_end`イベントが各ポインターで多重発火してしまう
   - 期待される挙動：最初のポインターでのみ`drag_start`を発火し、最後のポインターのリリース時にのみ`drag_end`を発火させる

#### 影響度
Patch: 既存機能の不具合修正であり、APIの互換性は維持されています。

#### 実装の詳細
1. スロットリング機構の改善
   - ポインター固有のイベントスロットリングを実装
   - 各ポインターのイベントを独立して処理
   - マルチタッチシナリオでのイベント発火タイミングを最適化

2. マルチタッチ制御の改善
   - 適切なイベントライフサイクル管理の実装：
     - 最初のポインターでのみdrag_startイベントを発火
     - 最後のポインターのリリース時のみdrag_endイベントを発火
   - ピンチ操作中のドラッグイベントを適切に制御

#### テストの変更内容
以下のテストを追加し、修正の有効性を検証：
- マルチタッチ時のイベントスロットリング検証
- マルチタッチ環境でのdrag_start/drag_endイベントの単一発火検証
- 複数ポインターの制御検証

変更されたテストファイル：
- `__test__/drag.pinch.spec.ts`
- `__test__/WatcherGenerator.ts`

#### 依存モジュールの状態
依存モジュールの変更はありません。

#### 補足情報
修正の検証と動作確認のため、以下の補助的な変更を実施：
- デバッグ情報表示機能の追加
- ピンチイベントのデモページの実装