### PR TITLE
Migrate to NPM Trusted Publisher and remove CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,0 @@
-exclude_patterns:
-  - "lib/"
-  - "esm/"
-  - "docs/"
-  - "__test__/"

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   npm-publish:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write  # Required for OIDC authentication
+      contents: read   # Required for repository access
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -14,10 +17,10 @@ jobs:
           node-version: "20"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm to v11.6.0
+        run: npm install -g npm@11.6.0
       - run: npm ci
       - name: build binary
         run: npm run buildTS
       - name: Publish package on NPM 📦
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![CI](https://github.com/MasatoMakino/threejs-drag-watcher/actions/workflows/ci_main.yml/badge.svg)](https://github.com/MasatoMakino/threejs-drag-watcher/actions/workflows/ci_main.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/4e6af8cf2633533bb04d/maintainability)](https://codeclimate.com/github/MasatoMakino/threejs-drag-watcher/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/4e6af8cf2633533bb04d/test_coverage)](https://codeclimate.com/github/MasatoMakino/threejs-drag-watcher/test_coverage)
 
 [![ReadMe Card](https://github-readme-stats.vercel.app/api/pin/?username=MasatoMakino&repo=threejs-drag-watcher)](https://github.com/MasatoMakino/threejs-drag-watcher)
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "lib": "esm"
   },
   "lint-staged": {
-    "*.{js,ts,css,md}": "npx biome check --write"
+    "*.{js,ts,css,md}": "biome format --write --no-errors-on-unmatched"
   }
 }


### PR DESCRIPTION
## Summary

This PR migrates npm package publishing from token-based authentication to NPM Trusted Publisher with OIDC authentication and removes CodeClimate integration.

## Changes

- ✅ NPM Trusted Publisher configured on npmjs.com
- ✅ Publishing access set to "Require two-factor authentication and disallow tokens"
- ✅ Added OIDC permissions to GitHub Actions workflow
- ✅ Added npm upgrade step for latest OIDC support
- ✅ Removed NPM token authentication from workflow
- ✅ Removed CodeClimate badges from README
- ✅ Removed `.codeclimate.yml` configuration file
- ✅ Fixed lint-staged configuration

## Security Improvements

- Enhanced security through OIDC authentication
- Provenance statements for package integrity
- Elimination of long-lived tokens
- Two-factor authentication requirement

## Testing

The migration can be tested by creating a release after this PR is merged. The workflow should successfully publish to NPM using Trusted Publisher authentication.

🤖 Generated with [Claude Code](https://claude.ai/code)